### PR TITLE
Befehl git vor difftool hinzugefügt

### DIFF
--- a/cheatsheet/sheets/cheatsheet.md
+++ b/cheatsheet/sheets/cheatsheet.md
@@ -29,7 +29,7 @@ $ git diff
 Zeigt alle Änderungen bei bereits getrackten Dateien an (Dateiinhalt)
 
 ```
-$ difftool
+$ git difftool
 ```
 Öffnet ein grafisches Tool um Änderungen anzuzeigen
 


### PR DESCRIPTION
Ich habe im Cheatsheet einen Fehler gefunden, wenn man grafisch die Differenzen anzeigen lassen möchte. Es fehlte ein **git** vor difftool.